### PR TITLE
Show local timezone instead of UTC?

### DIFF
--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -97,6 +97,7 @@ library
                      , mtl ^>= 2.2.2
                      , stm >= 2.4 && < 2.6
                      , text ^>= 1.2.3
+                     , time >= 1.4 && <1.12
                      , chronos ^>= 1.1
                      , transformers ^>= 0.5
                      , typerep-map ^>= 0.3.2


### PR DESCRIPTION
First I need to apologize because this is more a question than a pull request; but it's so much easier to communicate an idea with some accompanying code 😀 

So, should co-log always use UTC as time zone output? 
Personally I'm unsure what is the "correct" behaviour, so I started this experiment to use the local time zone as an default instead.

Please note that this adds the `time` package as a dependency to `co-log` (but it was a transitive dependency before, so it shouldn't add to the footprint of the library).

So just tell me what do you think?