### PR TITLE
Derive `MonadFail` for `LoggerT`

### DIFF
--- a/src/Colog/Monad.hs
+++ b/src/Colog/Monad.hs
@@ -34,7 +34,7 @@ import Colog.Core (HasLog (..), LogAction (..), overLogAction, hoistLogAction)
 -}
 newtype LoggerT msg m a = LoggerT
     { runLoggerT :: ReaderT (LogAction (LoggerT msg m) msg) m a
-    } deriving newtype ( Functor, Applicative, Monad, MonadIO
+    } deriving newtype ( Functor, Applicative, Monad, MonadIO, MonadFail
                        , MonadReader (LogAction (LoggerT msg m) msg)
                        )
 


### PR DESCRIPTION
Not a complete fix for #134, but at least provide one more instance for `base` classes. Given `ReaderT` provides instances for many more classes (many of them in `base` or `mtl` which are dependencies already), more could be added.

See: https://github.com/co-log/co-log/issues/134