### PR TITLE
Allow building with GHC 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,18 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         cabal: ["3.6.2.0"]
         ghc:
-          - "8.10.7"
-          - "9.0.2"
+          - 8.10.7
+          - 9.0.2
+          - 9.2.4
         exclude:
           - os: macOS-latest
             ghc: 8.10.7
-
+          - os: macOS-latest
+            ghc: 9.0.2
           - os: windows-latest
             ghc: 8.10.7
+          - os: windows-latest
+            ghc: 9.0.2
 
     steps:
     - uses: actions/checkout@v3

--- a/co-log.cabal
+++ b/co-log.cabal
@@ -23,13 +23,14 @@ extra-doc-files:     CHANGELOG.md
                      README.md
 tested-with:         GHC == 8.10.7
                      GHC == 9.0.2
+                     GHC == 9.2.4
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/co-log.git
 
 common common-options
-  build-depends:       base >= 4.14 && < 4.16
+  build-depends:       base >= 4.14 && < 4.17
 
   ghc-options:         -Wall
                        -Wcompat

--- a/src/Colog/Message.hs
+++ b/src/Colog/Message.hs
@@ -457,7 +457,7 @@ builderDmyHMSz (C.OffsetDatetime (C.Datetime date time) offset) =
     spaceSep :: TB.Builder
     spaceSep = TB.singleton ' '
 
-    {- | Given a 'Date' construct a 'Text' 'TB.Builder'
+    {- Given a 'Date' construct a 'Text' 'TB.Builder'
     corresponding to a Day\/Month\/Year encoding.
 
     Example: @01 Jan 2020@

--- a/tutorials/Main.hs
+++ b/tutorials/Main.hs
@@ -44,7 +44,7 @@ simpleApp = do
 app :: (WithLog env Message m, MonadIO m) => m ()
 app = do
     logWarning "Starting application..."
-    liftIO $ threadDelay $ 10^(6 :: Int)
+    liftIO $ threadDelay $ 10 ^ (6 :: Int)
     withLog (cmap addApp) $ do
         example
         exceptionL


### PR DESCRIPTION
I'd love to be able to compile a project of mine (which has co-log as dependency) with GHC 9.2.4.

Could you please accept this PR bumping base version bound for that purpose?
I also extended CI config and fixed 2 warnings issues by the new version of ghc..