### PR TITLE
docs: refine readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # co-log
+<img align="left" width="180" height="180" src="https://user-images.githubusercontent.com/8126674/80955687-92f21a80-8df7-11ea-90d3-422dafdc8391.png">
 
-![Co-logo](https://user-images.githubusercontent.com/8126674/80955687-92f21a80-8df7-11ea-90d3-422dafdc8391.png)
 
 [![GitHub CI](https://github.com/kowainik/co-log/workflows/CI/badge.svg)](https://github.com/kowainik/co-log/actions)
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/co-log/blob/main/LICENSE)
@@ -14,6 +14,7 @@ examples, explanations and tutorials to guide users. The combination of a
 pragmatic approach to logging and fundamental Haskell abstractions allows us to
 create a highly composable and configurable logging framework.
 
+--- 
 If you're interested in how different Haskell typeclasses are used to
 implement core functions of `co-log`, you can read the following blog
 post which goes into detail about the internal implementation specifics:
@@ -141,12 +142,13 @@ smoothly:
 
 * [Intro: Using `LogAction`](./tutorials/1-intro/Intro.md)
 * [Using custom monad that stores `LogAction` inside its environment](./tutorials/2-custom/Custom.md)
+* [All supported log behaviours in co-log](./tutorials/Main.hs)
 
 `co-log` also cares about concurrent logging. For this purpose we have the `concurrent-playground`
 executable where we experiment with different multithreading scenarios to test the library's behavior.
 You can find it here:
 
-* [tutorials/Concurrent.hs](tutorials/Concurrent.hs)
+* [tutorials/Concurrent.hs](./tutorials/Concurrent.hs)
 
 [hk-img]: https://img.shields.io/hackage/v/co-log.svg?logo=haskell
 [hk-img-ps]: https://img.shields.io/hackage/v/co-log-polysemy.svg?logo=haskell


### PR DESCRIPTION
- fix the broken link of the concurrent tutorial on https://hackage.haskell.org/package/co-log
- adjust logo position
- add the link to all possible usages