### PR TITLE
docs: add a link to tutorial pages and aggregate all tutorial pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # co-log
-<img align="left" width="180" height="180" src="https://user-images.githubusercontent.com/8126674/80955687-92f21a80-8df7-11ea-90d3-422dafdc8391.png">
 
+<img align="left" width="180" height="180" src="https://user-images.githubusercontent.com/8126674/80955687-92f21a80-8df7-11ea-90d3-422dafdc8391.png">
 
 [![GitHub CI](https://github.com/kowainik/co-log/workflows/CI/badge.svg)](https://github.com/kowainik/co-log/actions)
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/co-log/blob/main/LICENSE)
@@ -14,12 +14,13 @@ examples, explanations and tutorials to guide users. The combination of a
 pragmatic approach to logging and fundamental Haskell abstractions allows us to
 create a highly composable and configurable logging framework.
 
---- 
+---
+
 If you're interested in how different Haskell typeclasses are used to
 implement core functions of `co-log`, you can read the following blog
 post which goes into detail about the internal implementation specifics:
 
-* [co-log: Composable Contravariant Combinatorial Comonadic Configurable Convenient Logging](https://kowainik.github.io/posts/2018-09-25-co-log)
+- [co-log: Composable Contravariant Combinatorial Comonadic Configurable Convenient Logging](https://kowainik.github.io/posts/2018-09-25-co-log)
 
 ## Co-Log Family
 
@@ -29,12 +30,12 @@ framework `co-log`.
 Here is the list of currently available repositories and libraries that you can
 check out:
 
-|                                                                   |                                                                                                                                                        |                                    |
-| :---------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------- |
-| [`co-log-core`](https://github.com/co-log/co-log-core)            | lightweight package with basic data types and general idea which depends only on `base`                                                                | [![Hackage][hk-img-core]][hk-core] |
-| [`co-log`](https://github.com/co-log/co-log)                      | taggless final implementation of logging library based on `co-log-core`                                                                                | [![Hackage][hk-img]][hk]           |
-| [`co-log-polysemy`](https://github.com/co-log/co-log-polysemy)    | implementation of logging library based on `co-log-core` and the [`polysemy`](http://hackage.haskell.org/package/polysemy) extensible effects library. | [![Hackage][hk-img-ps]][hk-ps]     |
-| [`co-log-benchmarks`](https://github.com/co-log/co-log-benchmarks) | benchmarks of the `co-log` library                                                                                                                     | -
+|                                                                    |                                                                                                                                                        |                                    |
+| :----------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------- |
+| [`co-log-core`](https://github.com/co-log/co-log-core)             | lightweight package with basic data types and general idea which depends only on `base`                                                                | [![Hackage][hk-img-core]][hk-core] |
+| [`co-log`](https://github.com/co-log/co-log)                       | taggless final implementation of logging library based on `co-log-core`                                                                                | [![Hackage][hk-img]][hk]           |
+| [`co-log-polysemy`](https://github.com/co-log/co-log-polysemy)     | implementation of logging library based on `co-log-core` and the [`polysemy`](http://hackage.haskell.org/package/polysemy) extensible effects library. | [![Hackage][hk-img-ps]][hk-ps]     |
+| [`co-log-benchmarks`](https://github.com/co-log/co-log-benchmarks) | benchmarks of the `co-log` library                                                                                                                     | -                                  |
 
 ## `co-log` library
 
@@ -138,17 +139,7 @@ And here is how output looks like:
 
 To provide a more user-friendly introduction to the library, we've
 created the tutorial series which introduces the main concepts behind `co-log`
-smoothly:
-
-* [Intro: Using `LogAction`](./tutorials/1-intro/Intro.md)
-* [Using custom monad that stores `LogAction` inside its environment](./tutorials/2-custom/Custom.md)
-* [All supported log behaviours in co-log](./tutorials/Main.hs)
-
-`co-log` also cares about concurrent logging. For this purpose we have the `concurrent-playground`
-executable where we experiment with different multithreading scenarios to test the library's behavior.
-You can find it here:
-
-* [tutorials/Concurrent.hs](./tutorials/Concurrent.hs)
+smoothly, please [check more details here](./tutorials/README.md).
 
 [hk-img]: https://img.shields.io/hackage/v/co-log.svg?logo=haskell
 [hk-img-ps]: https://img.shields.io/hackage/v/co-log-polysemy.svg?logo=haskell

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -2,10 +2,10 @@
 
 This directory contains examples of using `co-log` library written as literate Haskell tutorials. Considering some prefer to read the source code directly, there are `.hs` files inside the corresponding folder.
 
-
-|No|Tutorial|Brief Introduction|
-|--|--|--|
-|1|[LogAction: start to use co-log](1-intro/Intro.md)|In this tutorial, you will learn how to replace the `putStrLn` and `print` with `LogAction`|
-|2|[Simple message and LoggerT](2-loggert/README.md)|This tutorial will show you how to use `LoggerT` and Simple message to log with more information in a more flexiable way.|
-|3|[Using custom monad that stores `LogAction` inside its environment](2-custom/Custom.md)|This tutorial will show you how to custom monad to store `LogAction` inside its environment.|
-|4|[Collection of all common usages](Main.hs)|The code list all common usages about co-log, could check it to find out what you like.|
+| No  | Tutorial                                                                                | Brief Introduction                                                                                                                                                                                    |
+| --- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | [LogAction: start to use co-log](1-intro/Intro.md)                                      | In this tutorial, you will learn how to replace the `putStrLn` and `print` with `LogAction`                                                                                                           |
+| 2   | [Simple message and LoggerT](2-loggert/README.md)                                       | This tutorial will show you how to use `LoggerT` and Simple message to log with more information in a more flexiable way.                                                                             |
+| 3   | [Using custom monad that stores `LogAction` inside its environment](3-custom/Custom.md) | This tutorial will show you how to custom monad to store `LogAction` inside its environment.                                                                                                          |
+| 4   | [Collection of all common usages](Main.hs)                                              | The code list all common usages about co-log, could check it to find out what you like.                                                                                                               |
+| 5   | [Concurrent usages](Concurrent.hs)                                                      | co-log also cares about concurrent logging. For this purpose we have the concurrent-playground executable where we experiment with different multithreading scenarios to test the library's behavior. |


### PR DESCRIPTION
- aggregated all the tutorial pages together and put a link to the tutorial readme.
- format the markdown using the `Prettier` plugin.
- fix: previously, the second link with the title *Using custom monad that stores LogAction inside its environment* is wrong and caused a 404. I apologize for such a careless mistake and fixed it in this PR.

Regards