### PR TITLE
Create tags and upload package candidates on version bumps.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: cabal check
+
+      - uses: sol/haskell-autotag@v1
+        id: autotag
+        with:
+          prefix: v
+
+      - run: cabal sdist
+      - uses: haskell-actions/hackage-publish@v1.1
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
+          publish: false
+        if: steps.autotag.outputs.created


### PR DESCRIPTION
Edit think it might be a good idea to test this when releasing v0.6 (will provide another PR for release preparation when time has come).

Reminder for myself: Add my hackage token to org secrets before!